### PR TITLE
Fix xcode 16.1 compiler crash

### DIFF
--- a/ChatLayout/Classes/Core/Model/StateController.swift
+++ b/ChatLayout/Classes/Core/Model/StateController.swift
@@ -926,7 +926,7 @@ final class StateController<Layout: ChatLayoutRepresentation> {
             // Debug purposes only.
             var attributes = [ChatLayoutAttributes]()
             attributes.reserveCapacity(layout.sections.reduce(into: 0) { $0 += $1.items.count })
-            layout.sections.enumerated().forEach { sectionIndex, section in
+            for (sectionIndex, section) in layout.sections.enumerated() {
                 let sectionPath = ItemPath(item: 0, section: sectionIndex)
                 if let headerAttributes = itemAttributes(for: sectionPath, kind: .header, at: state, additionalAttributes: additionalAttributes) {
                     attributes.append(headerAttributes)
@@ -934,7 +934,7 @@ final class StateController<Layout: ChatLayoutRepresentation> {
                 if let footerAttributes = itemAttributes(for: sectionPath, kind: .footer, at: state, additionalAttributes: additionalAttributes) {
                     attributes.append(footerAttributes)
                 }
-                section.items.enumerated().forEach { itemIndex, _ in
+                for itemIndex in 0..<section.items.count {
                     let itemPath = ItemPath(item: itemIndex, section: sectionIndex)
                     if let itemAttributes = itemAttributes(for: itemPath, kind: .cell, at: state, additionalAttributes: additionalAttributes) {
                         attributes.append(itemAttributes)


### PR DESCRIPTION
The crash happened when compiling `StateController.allAttributes` function.

I randomly pulled the upstream version of `StateController.allAttributes` function, which accidentally helped.

How to reproduce the crash:
```
xcodes select 16.1

/usr/bin/xcrun xcodebuild -project ./ChatLayout.xcodeproj -scheme ChatLayout -configuration Release -sdk iphoneos ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= SUPPORTS_MACCATALYST=NO CARTHAGE=YES archive VALIDATE_WORKSPACE=NO -archivePath ./archive/ SKIP_INSTALL=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=NO CLANG_ENABLE_CODE_COVERAGE=NO STRIP_INSTALLED_PRODUCT=NO
```

