### PR TITLE
The minimum height reported by `collectionViewContentSize` added.

### DIFF
--- a/ChatLayout/Classes/Core/ChatLayoutSettings.swift
+++ b/ChatLayout/Classes/Core/ChatLayoutSettings.swift
@@ -29,4 +29,8 @@ public struct ChatLayoutSettings: Equatable {
     /// Additional insets for the `CollectionViewChatLayout` content.
     public var additionalInsets: UIEdgeInsets = .zero
 
+    /// The minimum height reported by `collectionViewContentSize`.
+    /// If the calculated content height is smaller than this value,
+    /// the layout returns this height instead.
+    public var minimumContentHeight: CGFloat = 0
 }

--- a/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
+++ b/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
@@ -132,7 +132,11 @@ public final class CollectionViewChatLayout: UICollectionViewLayout {
             }
             contentSize = size
         }
-        return contentSize
+
+        return CGSize(
+            width: contentSize.width,
+            height: max(contentSize.height, settings.minimumContentHeight)
+        )
     }
 
     /// There is an issue in IOS 15.1 that proposed content offset is being ignored by the UICollectionView when user is scrolling.


### PR DESCRIPTION
The minimum height reported by `collectionViewContentSize` added.
We need this functionality to support tabs with header UI (e.g Profile screen)

We have similar property in our custom layout `BaseCollectionLayout` class.

On the attached screenshot you can see that the Activity tab (that uses the ChatLayout) has enough space to scroll its content to the very top even if it has just one zerocase cell.

<img width="293" height="636" alt="Screenshot 2026-06-05 at 10 09 51" src="https://github.com/user-attachments/assets/fbc62aa6-d4b2-4920-a1b1-f43db2b5bbe7" />

The original issue:
[IOS-30775] - Activity Tab: Switching to activity tab unnecessarily scrolls to the very top of the profile page

[IOS-30775]: https://bandlab.atlassian.net/browse/IOS-30775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ